### PR TITLE
Added source path exclusion feature.

### DIFF
--- a/src/ContainerBuilderInterface.php
+++ b/src/ContainerBuilderInterface.php
@@ -15,6 +15,8 @@ interface ContainerBuilderInterface
 
     public function addSourcePath(string $path): ContainerBuilderInterface;
 
+    public function excludeSourcePath(string $path): ContainerBuilderInterface;
+
     public function addCompilerPass(CompilerPassInterface $compilerPass): ContainerBuilderInterface;
 
     public function build(): ContainerInterface;


### PR DESCRIPTION
Extended current implementation to allow source path exclusion. Added tests.

The path exclusion is done upon request, not at built time. That way the construction below is possible. Also no additional operations are performed if `excludeSourcePath()` is not used compared to current code.
```php
$containerBuilder->addSourcePath('src');
// Exclude all vendor extensions except guzzle
$containerBuilder->excludeSourcePath('src/Vendor');
$containerBuilder->addSourcePath('src/Vendor/GuzzleHttp');
```
