### PR TITLE
Prevent numbers from being removed from cache filename

### DIFF
--- a/src/SymfonyConfigCacheHandler/Builder.php
+++ b/src/SymfonyConfigCacheHandler/Builder.php
@@ -108,7 +108,7 @@ class Builder implements BuilderInterface
     private function translate(string $name): string
     {
         return take($name)
-            ->pipe('preg_replace', ...['/[^a-zA-Z ]/', '', PIPED_VALUE])
+            ->pipe('preg_replace', ...['/[^a-zA-Z0-9 ]/', '', PIPED_VALUE])
             ->pipe('ucwords')
             ->pipe('str_replace', ...[' ', '', PIPED_VALUE])
             ->get();


### PR DESCRIPTION
I've noticed that the filename of the cache container doesn't include numbers, although the name passed to the cacheHandlerBuilder does. Seems like the translate only keeps letters and white spaces. I can imagine API endpoints string with MV0 and MV1 differing only in the materialization number. Therefore it might be worth keeping digits as well.