### PR TITLE
Making aliases public when all services are public.

### DIFF
--- a/src/TinyContainerBuilder.php
+++ b/src/TinyContainerBuilder.php
@@ -110,6 +110,9 @@ final class TinyContainerBuilder implements ContainerBuilderInterface
             foreach ($this->getInternalContainer()->getDefinitions() as $definition) {
                 $definition->setPublic(true);
             }
+            foreach ($this->getInternalContainer()->getAliases() as $alias) {
+                $alias->setPublic(true);
+            }
         } else {
             foreach ($this->publicServices as $publicService) {
                 $this->getInternalContainer()->getDefinition($publicService)->setPublic(true);


### PR DESCRIPTION
I was comparing the test containers built by prefab 7 (using Protean Container Builder) and Prefab 8 (using this package). I noticed a difference in the alias definitions and traced it back to [this line](https://github.com/neighborhoods/Prefab/blob/7.x/http/fab/Prefab5/Protean/Container/Builder.php#L269).
When `setShouldRegisterAllServicesAsPublic(true)` is invoked on the Protean Container Builder it will also make all aliases public.
I don't see a reason why we shouldn't do the same.